### PR TITLE
Correct MySQL secret key prefixes

### DIFF
--- a/mysql/mysql-secret.yml
+++ b/mysql/mysql-secret.yml
@@ -13,10 +13,10 @@ data:
   #MARIADB_RANDOM_ROOT_PASSWORD: cm9vdA==   # "root"
   #MARIADB_USER: YWRtaW4=                   # "admin"
 
-  MYSQQL_ROOT_PASSWORD: cm9vdA==  # "root"
-  MYSQQL_PASSWORD: YWRtaW4=          # "admin"    
-  MYSQQL_DATABASE: ZGF0YWJhc2U=      # "database"
-  MYSQQL_ALLOW_EMPTY_ROOT_PASSWORD: ZmFsc2U=  # "false"
-  MYSQQL_RANDOM_ROOT_PASSWORD: cm9vdA==  # "root"
-  MYSQQL_USER: YWRtaW4=             # "admin"
+  MYSQL_ROOT_PASSWORD: cm9vdA==  # "root"
+  MYSQL_PASSWORD: YWRtaW4=          # "admin"    
+  MYSQL_DATABASE: ZGF0YWJhc2U=      # "database"
+  MYSQL_ALLOW_EMPTY_ROOT_PASSWORD: ZmFsc2U=  # "false"
+  MYSQL_RANDOM_ROOT_PASSWORD: cm9vdA==  # "root"
+  MYSQL_USER: YWRtaW4=             # "admin"
  


### PR DESCRIPTION
## Summary
- fix MySQL secret variable names in mysql-secret.yml

## Testing
- `yamllint mysql/mysql-secret.yml` *(fails: command not found)*
- `pip install yamllint` *(fails: Could not find a version that satisfies the requirement)*
- `kubectl apply --dry-run=client -f mysql/mysql-secret.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f1376e4c832cae5057f60369c543