### PR TITLE
Fix uninstall script messages

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-echo "Starting WordPress installation..."
+echo "Starting WordPress uninstallation..."
 kubectl delete -f mysql/mysql-pvc.yml
 
 kubectl delete -f mysql/mysql-pv.yml
@@ -11,4 +11,4 @@ kubectl delete -f wordpress/wordpress-secret.yml
 kubectl delete -f wordpress/wordpress-deployment.yml
 kubectl delete -f wordpress/wordpress-svc.yml
 
-echo "WordPress installation completed successfully."
+echo "WordPress uninstallation completed successfully."


### PR DESCRIPTION
## Summary
- Update uninstall messages to reflect WordPress uninstallation

## Testing
- `bash -n uninstall.sh`
- `bash uninstall.sh` *(fails: kubectl: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f4749ce8832ca592ce17a62a21ea