### PR TITLE
fix: correct database host for WordPress

### DIFF
--- a/wordpress/wordpress-secret.yml
+++ b/wordpress/wordpress-secret.yml
@@ -10,4 +10,4 @@ data:
   WORDPRESS_DB_NAME: ZGF0YWJhc2U=  # "database"
   WORDPRESS_DB_USER: YWRtaW4=     # "admin"
   WORDPRESS_DB_PASSWORD: YWRtaW4= # "admin"
-  WORDPRESS_DB_HOST: bXlzcWw6MzMwNgo=
+  WORDPRESS_DB_HOST: bXlzcWwtc3ZjOjMzMDY=  # "mysql-svc:3306"


### PR DESCRIPTION
## Summary
- update `WORDPRESS_DB_HOST` to point at `mysql-svc:3306`

## Testing
- `bash -n install.sh`
- `bash -n uninstall.sh`
- `kubectl version --client` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a2081fc050832c91a82cc2446c5425